### PR TITLE
Add Jest tests for formatJson

### DIFF
--- a/__tests__/background.test.js
+++ b/__tests__/background.test.js
@@ -1,0 +1,28 @@
+const { formatJson } = require('../background');
+
+describe('formatJson', () => {
+  it('formats API response into simplified object', () => {
+    const sample = {
+      word: 'test',
+      phonetics: [{ text: 't\u025bst' }],
+      meanings: [
+        {
+          partOfSpeech: 'noun',
+          definitions: [
+            { definition: 'a procedure', example: 'a test case' }
+          ]
+        }
+      ],
+      derivatives: ['testing']
+    };
+
+    const result = formatJson(sample);
+    expect(result).toEqual({
+      word: 'test',
+      phonetic: '/t\u025bst/',
+      pos: 'noun',
+      defs: [{ text: 'a procedure', example: 'a test case' }],
+      derivs: ['testing']
+    });
+  });
+});

--- a/background.js
+++ b/background.js
@@ -52,3 +52,8 @@ function formatJson(entry) {
   const derivs  = entry.derivatives || entry.derivativeOf || [];
   return { word: entry.word, phonetic: phonText, pos, defs, derivs };
 }
+
+// Export for testing in Node environments
+if (typeof module !== 'undefined') {
+  module.exports = { formatJson };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dictionary-addon",
+  "version": "1.0.0",
+  "description": "Testing setup for Dictionary Lookup",
+  "devDependencies": {
+    "jest": "^29.6.1"
+  },
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  }
+}


### PR DESCRIPTION
## Summary
- introduce Jest test framework
- expose `formatJson` for testing
- add unit test for `formatJson`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513c468fd0832689ffab299d5955a6