### PR TITLE
Fix Jest config and passing tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  setupFilesAfterEnv: ['<rootDir>/__tests__/browser-mock.js'],
+  testMatch: ['**/__tests__/**/*.test.js']
+};


### PR DESCRIPTION
## Summary
- add jest.config.js so Jest only runs `*.test.js` files
- ensure `browser-mock.js` is included as setup instead of a test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d6f235488326b7181d6eb56759f7